### PR TITLE
fixed meta blade component

### DIFF
--- a/resources/views/components/meta.blade.php
+++ b/resources/views/components/meta.blade.php
@@ -2,7 +2,7 @@
 {{-- Default --}}
 {{-- <link rel="canonical" href="{{ route('home') }}"/> --}}
 
-@isset($title)<title>{{ $title }}</title>>@endisset
+@isset($title)<title>{{ $title }}</title>@endisset
 
 <meta name="robots" content="index,follow"/> 
 <meta name="revisit-after" content="7 days">


### PR DESCRIPTION
This PR fixes the meta blade component which had an extra '>' at the end of the title tag. This caused unwanted behavior.